### PR TITLE
Improve the line_attributes test

### DIFF
--- a/j4james/line_attributes.sh
+++ b/j4james/line_attributes.sh
@@ -19,6 +19,7 @@ DECDWL=$'\e#6'			# Double Width Line
 echo -n ${CSI}'!p'
 echo -n ${CSI}'H'
 echo -n ${CSI}'J'
+echo -n ${CSI}'?7h'
 
 set_cursor_pos() {
   echo -n ${CSI}${1}';'${2}'H'
@@ -69,9 +70,12 @@ test_message 19 17 ' DECDHL ' ${DECDHLB}
 
 # Output a double-height sequence of text.
 set_cursor_pos 12 1
-yes '+' | tr -d '\n' | head -c 160
-test_message 12 17 ' DOUBLE ' ${DECDHLT}
-test_message 13 17 ' DOUBLE ' ${DECDHLB}
+echo ${DECDHLT}
+echo ${DECDHLB}
+set_cursor_pos 12 1
+yes '+' | tr -d '\n' | head -c 80
+test_message 12 17 ' DOUBLE '
+test_message 13 17 ' DOUBLE '
 
 # Render an image to try and reset the line attributes.
 set_cursor_pos 12 1

--- a/j4james/line_attributes.sh
+++ b/j4james/line_attributes.sh
@@ -2,6 +2,11 @@
 
 # Test of line attribute interactions with a Sixel image.
 
+# Placing an image on top of a double width/height line has no effect on the
+# dimensions of the image. It renders just as it would on a single width line.
+# Changing a line from single width to double width, after an image has been
+# output, will erase the image content on that line along with any text.
+
 CSI=$'\e['			# Control Sequence Introducer 
 DCS=$'\eP'			# Device Control String
 ST=$'\e\\'			# String Terminator
@@ -21,34 +26,20 @@ set_cursor_pos() {
 
 large_block() {
   set_cursor_pos ${1} ${2}
-  echo ${DCS}'2;1q#1'
+  echo ${DCS}';1q"20;1#1'
   if [[ ${3} == true ]]
   then
-    echo '!200~-'
-    echo '!200~-'
-    echo '!200~-'
-    echo '!200~-'
+    echo '!200^'
   else
-    echo '!20~!160N!20~-'
-    echo '!20~!160?!20~-'
-    echo '!20~!160?!20~-'
-    echo '!20~!160{!20~-'
+    echo '!20^!160P!20^'
   fi
   echo ${ST}
 }
 
-small_block() {
+small_blocks() {
   set_cursor_pos ${1} ${2}
-  echo ${DCS}'2;1q#1'
-  echo '!40~-'
-  echo '!40B-'
-  echo ${ST}
-}
-
-error_line() {
-  set_cursor_pos ${1} ${2}
-  echo ${DCS}'2;1q#2'
-  echo '!200N-'
+  echo ${DCS}';1q"10;1#1'
+  echo '!40]!520?!40]'
   echo ${ST}
 }
 
@@ -58,28 +49,38 @@ test_message() {
   echo "${3}"
 }
 
-test_message 5 33 '  Regular Size  '
+# Output some double-size text.
 test_message 6 17 ' DECDWL ' ${DECDWL}
 test_message 7 17 ' DECDHL ' ${DECDHLT}
 test_message 8 17 ' DECDHL ' ${DECDHLB}
 
-large_block 4 31 false
-small_block 6 14
-small_block 6 64
+# Render some images on top of that text.
+large_block 5 31 false
+small_blocks 6 11
 
-large_block 13 31 true
-small_block 15 14
-small_block 15 64
+# Render another set of images.
+large_block 16 31 true
+small_blocks 17 11
 
-test_message 14 33 '  Regular Size  '
-test_message 15 17 ' DECDWL ' ${DECDWL}
-test_message 16 17 ' DECDHL ' ${DECDHLT}
-test_message 17 17 ' DECDHL ' ${DECDHLB}
+# Output some double-size text on top of those images.
+test_message 17 17 ' DECDWL ' ${DECDWL}
+test_message 18 17 ' DECDHL ' ${DECDHLT}
+test_message 19 17 ' DECDHL ' ${DECDHLB}
 
-set_cursor_pos 11 20
-echo '||'
-error_line 11 31
-set_cursor_pos 11 1
-echo ${DECDWL}
+# Output a double-height sequence of text.
+set_cursor_pos 12 1
+yes '+' | tr -d '\n' | head -c 160
+test_message 12 17 ' DOUBLE ' ${DECDHLT}
+test_message 13 17 ' DOUBLE ' ${DECDHLB}
 
-set_cursor_pos 22 1
+# Render an image to try and reset the line attributes.
+set_cursor_pos 12 1
+echo ${DCS}';1q?'${ST}
+
+# Output additional text on those lines.
+test_message 12 9 ' SINGLE '
+test_message 13 9 ' SINGLE '
+test_message 12 100 ' SINGLE ' ${CSI}'15D'
+test_message 13 100 ' SINGLE ' ${CSI}'15D'
+
+set_cursor_pos 1 1


### PR DESCRIPTION
This is an attempt to improve the output of the test so that it looks reasonable on both a real VT340, as well as on modern terminals, that aren't necessarily limited in the same way. I've also added a section showing how sixel could be used to trick the VT340 into displaying both single-width and double-height text on the same line.

If everything has gone according to plan, I'm expecting the VT340 output to look like this:

![image](https://user-images.githubusercontent.com/4181424/137644741-c6f91c13-371e-481b-87f9-382c10cc4005.png)

On modern terminals, though, I'd expect the bottom half of the test to look better (changing line attributes wouldn't typically erase the content of the line), but the mix of single and double text is highly unlikely to work.

![image](https://user-images.githubusercontent.com/4181424/137644786-49e19563-1a37-474d-ab81-4be747d0e955.png)
